### PR TITLE
Update dtc overlay url

### DIFF
--- a/package/dtc-overlay/Config.in.host
+++ b/package/dtc-overlay/Config.in.host
@@ -6,4 +6,4 @@ config BR2_PACKAGE_HOST_DTC_OVERLAY
 
 	  This version is patched to support device tree overlays.
 
-	  https://github.com/atenart/dtc
+	  https://github.com/NextThingCo/dtc

--- a/package/dtc-overlay/dtc-overlay.mk
+++ b/package/dtc-overlay/dtc-overlay.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-DTC_OVERLAY_VERSION = 61bbb7e7719959dc70917ae855398d278afa99c7
-DTC_OVERLAY_SITE = $(call github,atenart,dtc,$(DTC_OVERLAY_VERSION))
+DTC_OVERLAY_VERSION = 93f8c3a7d6bb37cc414a7116264361cb737f2966
+DTC_OVERLAY_SITE = $(call github,NextThingCo,dtc,$(DTC_OVERLAY_VERSION))
 DTC_OVERLAY_LICENSE = GPLv2+/BSD-2c
 DTC_OVERLAY_LICENSE_FILES = README.license GPL
 DTC_OVERLAY_DEPENDENCIES = host-bison host-flex

--- a/package/dtc-overlay/dtc-overlay.mk
+++ b/package/dtc-overlay/dtc-overlay.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DTC_OVERLAY_VERSION = 93f8c3a7d6bb37cc414a7116264361cb737f2966
+DTC_OVERLAY_VERSION = 61bbb7e7719959dc70917ae855398d278afa99c7
 DTC_OVERLAY_SITE = $(call github,NextThingCo,dtc,$(DTC_OVERLAY_VERSION))
 DTC_OVERLAY_LICENSE = GPLv2+/BSD-2c
 DTC_OVERLAY_LICENSE_FILES = README.license GPL


### PR DESCRIPTION
The original dtc-overlay remote repo, required for compiling CHIP-buildroot, was deleted.  This updates the makefile URL to point to the current NTC repo instead.